### PR TITLE
Remove prettier from linters category

### DIFF
--- a/src/categories/code-linters.json
+++ b/src/categories/code-linters.json
@@ -1,11 +1,12 @@
 {
-  "name": "Code Linters",
-  "description": "Find and fix code problems before shipping to production",
+  "name": "Code Linters & Formatters",
+  "description": "Format code and fix problems before shipping to production",
   "packages": [
     "@typescript-eslint/eslint-plugin",
     "eslint",
     "hint",
     "jshint",
+    "prettier",
     "rome",
     "stylelint"
   ]

--- a/src/categories/code-linters.json
+++ b/src/categories/code-linters.json
@@ -6,7 +6,6 @@
     "eslint",
     "hint",
     "jshint",
-    "prettier",
     "rome",
     "stylelint"
   ]


### PR DESCRIPTION
Prettier is in no way a linter, it is only a code formatter

Thank you for contributing to the Node.js Toolbox catalog! 🙏

**Before submitting your pull request, please make sure:**

- [x] To use the _exact_ package name as it appears on NPM (and `npm install <package-name>`)
- [x] The packages are listed in alphabetical order
- [x] Packages aren't already listed in the same or a different category
- [x] Description doesn't have a dot (.) at the end
- [x] To format with Prettier before committing (`npm run prettier`)
