### PR TITLE
Add fast-jwt as an option for JWT libraries

### DIFF
--- a/src/categories/json-web-token.json
+++ b/src/categories/json-web-token.json
@@ -1,5 +1,5 @@
 {
   "name": "JSON Web Token (JWT)",
   "description": "Sign and verify JWTs in Node.js",
-  "packages": ["jose", "jsonwebtoken", "jwt-decode", "node-jose"]
+  "packages": ["fast-jwt", "jose", "jsonwebtoken", "jwt-decode", "node-jose"]
 }


### PR DESCRIPTION
Thank you for contributing to the Node.js Toolbox catalog! 🙏

Note: Node.js Toolbox is specifically for backend libraries. If a library works both in the browser AND in Node.js feel free to add it. Libraries that work ONLY in the browser are out of scope for now.

**Before submitting your pull request, please make sure:**

- [X] To use the _exact_ package name as it appears on NPM (and `npm install <package-name>`)
- [X] The packages are listed in alphabetical order
- [X] The package doesn't already exist in a different category
- [X] Description doesn't have a dot (.) at the end
- [X] To format with Prettier before committing (`npm run prettier`)

While the library has fewer downloads than node-jose, [it is used by fastify for example](https://github.com/fastify/fastify-jwt).

More information at https://github.com/nearform/fast-jwt