### PR TITLE
Add @inquirer/prompts to Command Line Prompts

### DIFF
--- a/src/categories/command-line-prompts.json
+++ b/src/categories/command-line-prompts.json
@@ -1,5 +1,5 @@
 {
   "name": "Command Line Prompts",
   "description": "Create interactive command line tools by asking for user input",
-  "packages": ["enquirer", "inquirer", "prompts"]
+  "packages": ["@inquirer/prompts", "enquirer", "inquirer", "prompts"]
 }


### PR DESCRIPTION
This is the modern version of `inquirer` (and powers the legacy API behind the scenes.)

**Before submitting your pull request, please make sure:**

- [x] To use the _exact_ package name as it appears on NPM (and `npm install <package-name>`)
- [x] The packages are listed in alphabetical order
- [x] The package doesn't already exist in a different category
- [x] Description doesn't have a dot (.) at the end
- [x] To format with Prettier before committing (`npm run prettier`)
