### PR TITLE
Added farjs-app to command-line-utilities.json

### DIFF
--- a/src/categories/command-line-utilities.json
+++ b/src/categories/command-line-utilities.json
@@ -6,6 +6,7 @@
     "args",
     "cac",
     "commander",
+    "farjs-app",
     "gluegun",
     "meow",
     "minimist",


### PR DESCRIPTION
Thank you for contributing to the Node.js Toolbox catalog! 🙏

Note: Node.js Toolbox is specifically for backend libraries. If a library works both in the browser AND in Node.js feel free to add it. Libraries that work ONLY in the browser are out of scope for now.

**Before submitting your pull request, please make sure:**

- [x] To use the _exact_ package name as it appears on NPM (and `npm install <package-name>`)
- [x] The packages are listed in alphabetical order
- [x] The package doesn't already exist in a different category
- [x] Description doesn't have a dot (.) at the end
- [ ] To format with Prettier before committing (`npm run prettier`)
